### PR TITLE
Add build and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,50 @@ This component provides the ability to read / write device data using Modbus TCP
 The basic usage of this component is based on the same concept as Modbus RTU protocol adapter.<br>
 In addition, planning to provide read / write capabilities for asset data based on simple asset modeling feature.<br>
 
+## Installation
+
+You can either use a prebuilt binary or build yourself.
+
+### Use prebuilt binary
+
+Download the following files from [releases](https://github.com/awslabs/aws-greengrass-labs-modbus-tcp-protocol-adapter/releases) page.
+
+- `ModbusTCP-<version>.jar`: Executable JAR file
+- `aws.greengrass.labs.ModbusTCP-<version>.yaml`: Recipe template
+
+Edit the following placeholders in recipe template.
+
+- `<MODBUS_TCP_HOST>`: Host name or IP address of Modbus TCP device.
+- `<MODBUS_TCP_PORT>`: Port number of Modbus TCP device.
+- `<MODBUS_TCP_UNIT_NAME>`: Unique name of Modbus TCP device. Used as the last part of IPC topic.
+- `<BUCKET_NAME>`: S3 bucket name, if uploaded ModbusTCP-1.0.0.jar to your S3 bucket.
+
+Follow the developer guide to [publish](https://docs.aws.amazon.com/greengrass/v2/developerguide/publish-components.html#publish-component-shell-commands) Modbus TCP protocol adapter or [deploy locally](https://docs.aws.amazon.com/greengrass/v2/developerguide/gg-cli-deployment.html#deployment-create).
+
+### How to build
+
+If you choose to build yourself, you can build by the following steps below.
+
+#### Prerequisite
+
+Install Java Development Kit 11 or above. We recommend that you use [Amazon Corretto 11](http://aws.amazon.com/corretto/) or [OpenJDK 11](https://openjdk.java.net/).
+
+#### Build
+
+Checkout this repository, `cd` to the repository root, and execute the following command.
+
+For Linux
+```bash
+./gradlew jar
+```
+
+For Windows
+```
+.\gradlew jar
+```
+
+If successful, a JAR file will be created in `build/libs`.
+
 ## Usage
 
 ### Configure the component

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
     application
 }
 
-group = "com.amazon.iot.greengrass"
-version = "1.0"
+group = "aws.greengrass.labs.modbustcp"
+version = "1.0.0"
 
 repositories {
     mavenCentral()

--- a/samples/recipe/aws.greengrass.labs.ModbusTCP-1.0.0.yaml
+++ b/samples/recipe/aws.greengrass.labs.ModbusTCP-1.0.0.yaml
@@ -29,4 +29,4 @@ Manifests:
     os: linux
   Lifecycle:
     Run: |-
-        java -jar {artifacts:path}/ModbusTCP-1.0.jar
+        java -jar {artifacts:path}/ModbusTCP-1.0.0.jar

--- a/samples/recipe/aws.greengrass.labs.ModbusTCP-1.0.0.yaml
+++ b/samples/recipe/aws.greengrass.labs.ModbusTCP-1.0.0.yaml
@@ -9,24 +9,35 @@ ComponentConfiguration:
   DefaultConfiguration:
     Modbus:
       Endpoints:
-      - Host: "localhost"
-        Port: 5020
-        Devices:
-        - Name: "test"
-          UnitId: 0
+        - Host: <MODBUS_TCP_HOST>
+          Port: 502
+          Devices:
+            - Name: "test"
+              UnitId: 0
     accessControl:
       aws.greengrass.ipc.pubsub:
-        com.example.Modbus:pubsub:1:
-          policyDescription: "Allows publish/subscribe to all topics."
+        "aws.greengrass.labs.ModbusTCP:pubsub:1":
+          policyDescription: "Allows publish to request topic."
           operations:
-          - "aws.greengrass#PublishToTopic"
-          - "aws.greengrass#SubscribeToTopic"
+            - "aws.greengrass#PublishToTopic"
           resources:
-          - "*"
+            - "modbus/request/test"
+        "aws.greengrass.labs.ModbusTCP:pubsub:2":
+          policyDescription: "Allows subscribe to response topic."
+          operations:
+            - "aws.greengrass#SubscribeToTopic"
+          resources:
+            - "modbus/response/test"
 Manifests:
-- Name: Linux
-  Platform:
-    os: linux
-  Lifecycle:
-    Run: |-
+  - Name: UNIX
+    Platform:
+      os: /linux|darwin/
+    Lifecycle:
+      Run: |-
         java -jar {artifacts:path}/ModbusTCP-1.0.0.jar
+  - Name: Windows
+    Platform:
+      os: windows
+    Lifecycle:
+      Run: |-
+        java -jar {artifacts:path}\ModbusTCP-1.0.0.jar

--- a/src/test/resources/device_test.yaml
+++ b/src/test/resources/device_test.yaml
@@ -4,6 +4,7 @@ services:
     configuration:
       runWithDefault:
         posixUser: nobody
+      awsRegion: "us-east-1"
   SubscribeAndPublish:
     configuration:
       accessControl:

--- a/src/test/resources/integration_test.yaml
+++ b/src/test/resources/integration_test.yaml
@@ -4,6 +4,7 @@ services:
     configuration:
       runWithDefault:
         posixUser: nobody
+      awsRegion: "us-east-1"
   Integration:
     configuration:
       accessControl:


### PR DESCRIPTION
Closes #1 

*Description of changes:*
- Add build and install instructions
- Modify sample recipe template
- Fix a bug that integration test fails in environment without `.aws/config` file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
